### PR TITLE
fix config handling and code cleanup

### DIFF
--- a/src/main/java/com/bawnorton/dabrsc/DABRCS.java
+++ b/src/main/java/com/bawnorton/dabrsc/DABRCS.java
@@ -19,27 +19,30 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class DABRCS extends JavaPlugin implements Listener {
     private static final String CONFIG_SYNC_CHANNEL = "do_a_barrel_roll:config_sync";
 
-    private final FileConfiguration config = this.getConfig();
-    private FoliaLib foliaLib = null;
+    private FoliaLib foliaLib;
 
     @Override
     public void onEnable() {
         foliaLib = new FoliaLib(this);
 
-        this.config.addDefault("allowThrusting", true);
-        this.config.addDefault("forceEnabled", false);
-        this.config.addDefault("sendChatFeedback", true);
-        this.saveConfig();
+        // Ensure config file exists and defaults are actually written when missing
+        saveDefaultConfig();
+        getConfig().addDefault("allowThrusting", true);
+        getConfig().addDefault("forceEnabled", false);
+        getConfig().addDefault("sendChatFeedback", true);
+        getConfig().options().copyDefaults(true);
+        saveConfig();
 
-        this.getServer().getPluginManager().registerEvents(this, this);
-        this.getServer().getMessenger().registerOutgoingPluginChannel(this, CONFIG_SYNC_CHANNEL);
-        this.getServer().getMessenger().registerIncomingPluginChannel(this, CONFIG_SYNC_CHANNEL,
+        getServer().getPluginManager().registerEvents(this, this);
+        getServer().getMessenger().registerOutgoingPluginChannel(this, CONFIG_SYNC_CHANNEL);
+        getServer().getMessenger().registerIncomingPluginChannel(this, CONFIG_SYNC_CHANNEL,
                 (channel, player, message) -> {
                     ByteArrayDataInput in = ByteStreams.newDataInput(message);
                     int version = in.readInt();
                     boolean success = in.readBoolean();
-                    if (this.config.getBoolean("sendChatFeedback"))
+                    if (getConfig().getBoolean("sendChatFeedback")) {
                         player.sendMessage("Response from DABR (" + version + "): Success:" + success);
+                    }
                 });
 
         Objects.requireNonNull(getCommand("dabrcs"), "unreachable")
@@ -56,14 +59,12 @@ public final class DABRCS extends JavaPlugin implements Listener {
 
                     if (strings.length == 1) {
                         if (strings[0].equals("allowThrusting")) {
-                            commandSender.sendMessage(
-                                    "allowThrusting is currently " + this.config.getBoolean("allowThrusting"));
+                            commandSender.sendMessage("allowThrusting is currently " + getConfig().getBoolean("allowThrusting"));
                             return true;
                         }
 
                         if (strings[0].equals("forceEnabled")) {
-                            commandSender
-                                    .sendMessage("forceEnabled is currently " + this.config.getBoolean("forceEnabled"));
+                            commandSender.sendMessage("forceEnabled is currently " + getConfig().getBoolean("forceEnabled"));
                             return true;
                         }
 
@@ -73,19 +74,18 @@ public final class DABRCS extends JavaPlugin implements Listener {
 
                     if (strings.length == 2) {
                         if (strings[0].equals("allowThrusting")) {
-                            this.config.set("allowThrusting", Boolean.parseBoolean(strings[1]));
-                            this.saveConfig();
-                            this.sendConfigToAllPlayers();
-                            commandSender
-                                    .sendMessage("Set allowThrusting to " + this.config.getBoolean("allowThrusting"));
+                            getConfig().set("allowThrusting", Boolean.parseBoolean(strings[1]));
+                            saveConfig();
+                            sendConfigToAllPlayers();
+                            commandSender.sendMessage("Set allowThrusting to " + getConfig().getBoolean("allowThrusting"));
                             return true;
                         }
 
                         if (strings[0].equals("forceEnabled")) {
-                            this.config.set("forceEnabled", Boolean.parseBoolean(strings[1]));
-                            this.saveConfig();
-                            this.sendConfigToAllPlayers();
-                            commandSender.sendMessage("Set forceEnabled to " + this.config.getBoolean("forceEnabled"));
+                            getConfig().set("forceEnabled", Boolean.parseBoolean(strings[1]));
+                            saveConfig();
+                            sendConfigToAllPlayers();
+                            commandSender.sendMessage("Set forceEnabled to " + getConfig().getBoolean("forceEnabled"));
                             return true;
                         }
 
@@ -96,19 +96,32 @@ public final class DABRCS extends JavaPlugin implements Listener {
                     commandSender.sendMessage("Usage: /dabrcs <allowThrusting|forceEnabled> <true|false>");
                     return true;
                 });
-        this.getLogger().info("Loaded DABRCS");
+
+        getLogger().info("Loaded DABRCS");
     }
 
     @Override
     public void onDisable() {
-        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
-        this.getLogger().info("Unloaded DABRCS");
+        getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+        getLogger().info("Unloaded DABRCS");
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        this.foliaLib.getScheduler().runAtEntityLater(player, () -> this.sendConfig(player), 20L, TimeUnit.MILLISECONDS);
+
+        // 20 ms was likely too soon for client/mod channel readiness on join.
+        foliaLib.getScheduler().runAtEntityLater(
+                player,
+                () -> {
+                    getLogger().info("Sending join config to " + player.getName()
+                            + " allowThrusting=" + getConfig().getBoolean("allowThrusting")
+                            + " forceEnabled=" + getConfig().getBoolean("forceEnabled"));
+                    sendConfig(player);
+                },
+                1L,
+                TimeUnit.SECONDS
+        );
     }
 
     private void writeVarInt(ByteArrayDataOutput out, int value) {
@@ -116,21 +129,23 @@ public final class DABRCS extends JavaPlugin implements Listener {
             out.writeByte(value & 127 | 128);
             value >>>= 7;
         }
-
         out.writeByte(value);
     }
 
     private void sendConfigToAllPlayers() {
-        for (Player player : this.getServer().getOnlinePlayers())
-            this.sendConfig(player);
+        for (Player player : getServer().getOnlinePlayers()) {
+            sendConfig(player);
+        }
     }
 
     private void sendConfig(Player player) {
+        FileConfiguration config = getConfig();
+
         ByteArrayDataOutput out = ByteStreams.newDataOutput();
 
         out.writeInt(4);
-        out.writeBoolean(this.config.getBoolean("allowThrusting"));
-        out.writeBoolean(this.config.getBoolean("forceEnabled"));
+        out.writeBoolean(config.getBoolean("allowThrusting"));
+        out.writeBoolean(config.getBoolean("forceEnabled"));
         out.writeBoolean(true);
         out.writeBoolean(false);
         out.writeBoolean(false);
@@ -138,10 +153,9 @@ public final class DABRCS extends JavaPlugin implements Listener {
         out.writeInt(0);
 
         String value = "VANILLA";
-        this.writeVarInt(out, value.length());
+        writeVarInt(out, value.length());
         out.write(value.getBytes(StandardCharsets.UTF_8));
 
-        DABRCS plugin = JavaPlugin.getPlugin(DABRCS.class);
-        player.sendPluginMessage(plugin, CONFIG_SYNC_CHANNEL, out.toByteArray());
+        player.sendPluginMessage(this, CONFIG_SYNC_CHANNEL, out.toByteArray());
     }
 }


### PR DESCRIPTION
Full disclosure; this was slopcoded in 2 minutes because I was pulling my hair out trying to get the server config to properly save on Paper 1.21.11. I'd set the config, players would rejoin, and allowThrusting would be disabled again. 

It seems to work as far as properly saving and dispersing the config, but I am basically clueless when it comes to java so take this with a mountain of salt.